### PR TITLE
docker compose 部署方式

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,0 +1,20 @@
+redis:
+  image: redis:3.2.4-alpine
+  expose:
+    - "6379"
+mysql:
+  image: mysql:5.6.33
+  expose:
+    - "3306"
+  environment:
+    - MYSQL_ROOT_PASSWORD=root
+  volumes:
+    - /var/lib/mysql/data:/var/lib/mysql
+    - /var/lib/mysql/init:/docker-entrypoint-initdb.d
+rap:
+  image: rap:0.14.1
+  ports:
+    - "8088:8080"
+  links:
+    - mysql
+    - redis

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -14,7 +14,7 @@ mysql:
 rap:
   image: huangfushun/rap:0.14.1
   ports:
-    - "8088:8080"
+    - "80:8080"
   links:
     - mysql
     - redis

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ mysql:
     - /var/lib/mysql/data:/var/lib/mysql
     - /var/lib/mysql/init:/docker-entrypoint-initdb.d
 rap:
-  image: rap:0.14.1
+  image: huangfushun/rap:0.14.1
   ports:
     - "8088:8080"
   links:

--- a/docker-compose/init_db.sh
+++ b/docker-compose/init_db.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+export RAP_VERSION=0.14.1
+export MYSQL_DATA_DIR=/var/lib/mysql/data
+export MYSQL_INIT_SQL_DIR=/var/lib/mysql/init
+mkdir -p $MYSQL_DATA_DIR
+mkdir -p $MYSQL_INIT_SQL_DIR
+if [ ! -f "$MYSQL_INIT_SQL_DIR/initialize.sql" ]; then
+wget -O $MYSQL_INIT_SQL_DIR/initialize.sql  https://raw.githubusercontent.com/thx/RAP/release/src/main/resources/database/initialize.sql
+fi


### PR DESCRIPTION
允许用户在linux环境通过docker compose 启动 rap应用
1. 执行init_db.sh 创建mysql目录及下载初始化sql
2. docker-compose up 启动应用
3. rap tomcat镜像发布在docker.io
#907 