### PR TITLE
fix(sec): upgrade org.apache.logging.log4j:log4j-core to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.5</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>com.belerweb</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.logging.log4j:log4j-core 2.5
- [CVE-2020-9488](https://www.oscs1024.com/hd/CVE-2020-9488)


### What did I do？
Upgrade org.apache.logging.log4j:log4j-core from 2.5 to 2.17.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>