### PR TITLE
fix(sec): upgrade org.apache.struts:struts2-core to 2.5.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-core</artifactId>
-            <version>2.3.32</version>
+            <version>2.5.30</version>
             <exclusions>
                 <exclusion>
                     <artifactId>javassist</artifactId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.struts:struts2-core 2.3.32
- [CVE-2021-31805](https://www.oscs1024.com/hd/CVE-2021-31805)


### What did I do？
Upgrade org.apache.struts:struts2-core from 2.3.32 to 2.5.30 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>